### PR TITLE
Show percentage of assessable income paid in taxes in heatmap instead of just tax amount

### DIFF
--- a/taxes/tax.ipynb
+++ b/taxes/tax.ipynb
@@ -749,11 +749,8 @@
     "        .apply(pd.Series)\n",
     ")\n",
     "\n",
-    "ind_income_tax_df[\"Mean Net Tax Assessed\"] = (ind_income_tax_df[\"Net Tax Assessed\"] / ind_income_tax_df[\"Number of Tax Payers\"]) * 1_000\n",
+    "ind_income_tax_df[\"Tax-Income Percentage\"] = (ind_income_tax_df[\"Net Tax Assessed\"] / ind_income_tax_df[\"Assessable Income\"]) * 100\n",
     "ind_income_tax_df = ind_income_tax_df.fillna(0)\n",
-    "\n",
-    "ind_income_tax_df[\"Log Mean Net Tax Assessed\"] = np.log10(ind_income_tax_df[\"Mean Net Tax Assessed\"])\n",
-    "ind_income_tax_df = ind_income_tax_df.replace(-float(\"inf\"), 0)\n",
     "\n",
     "ind_income_tax_df = ind_income_tax_df.sort_values([\"Year of Assessment\", \"Upper Bound\"])\n",
     "ind_income_tax_df"
@@ -766,13 +763,45 @@
    "outputs": [],
    "source": [
     "# \"Upper Bound\" is added as an index to sort the data frame. It is removed immediately after.\n",
-    "ind_income_tax_heatmap_df = ind_income_tax_df.pivot(\n",
+    "ind_income_tax_net_tax_df = ind_income_tax_df.pivot(\n",
     "    index=[\"Upper Bound\", \"Assessed Income Group\"],\n",
     "    columns=\"Year of Assessment\",\n",
-    "    values=\"Mean Net Tax Assessed\"\n",
+    "    values=\"Net Tax Assessed\"\n",
     ").sort_values(\"Upper Bound\", ascending=False)\n",
-    "ind_income_tax_heatmap_df = ind_income_tax_heatmap_df.reset_index(\"Upper Bound\", drop=True)\n",
-    "ind_income_tax_heatmap_df"
+    "ind_income_tax_net_tax_df = ind_income_tax_net_tax_df.reset_index(\"Upper Bound\", drop=True)\n",
+    "ind_income_tax_net_tax_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# \"Upper Bound\" is added as an index to sort the data frame. It is removed immediately after.\n",
+    "ind_income_tax_assessable_income_df = ind_income_tax_df.pivot(\n",
+    "    index=[\"Upper Bound\", \"Assessed Income Group\"],\n",
+    "    columns=\"Year of Assessment\",\n",
+    "    values=\"Assessable Income\"\n",
+    ").sort_values(\"Upper Bound\", ascending=False)\n",
+    "ind_income_tax_assessable_income_df = ind_income_tax_assessable_income_df.reset_index(\"Upper Bound\", drop=True)\n",
+    "ind_income_tax_assessable_income_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Weird shenanigans.\n",
+    "customdata = np.stack(\n",
+    "    (\n",
+    "        ind_income_tax_assessable_income_df[::-1].transpose().to_numpy().flatten(),\n",
+    "        ind_income_tax_net_tax_df[::-1].transpose().to_numpy().flatten(),\n",
+    "    ),\n",
+    "    axis=-1\n",
+    ")"
    ]
   },
   {
@@ -793,19 +822,20 @@
     "    go.Heatmap(\n",
     "        x = ind_income_tax_df[\"Year of Assessment\"],\n",
     "        y = ind_income_tax_df[\"Assessed Income Group\"],\n",
-    "        z = ind_income_tax_df[\"Log Mean Net Tax Assessed\"],\n",
+    "        z = ind_income_tax_df[\"Tax-Income Percentage\"],\n",
     "        colorscale=\"Viridis\",\n",
     "        colorbar=dict(\n",
-    "            title=\"Mean Net Tax Assessed\",\n",
-    "            tickvals=[0, 1, 2, 3, 4, 5, 6],\n",
-    "            ticktext=[\"0\", \"S$10\", \"S$100\", \"S$1,000\", \"S$10,000\", \"S$100,000\", \"S$1,000,000\"],\n",
+    "            title=\"Percentage of Asssessed Income Paid in Taxes\",\n",
+    "            tickvals=[0, 5, 10, 15, 20],\n",
+    "            ticktext=[\"0%\", \"5%\", \"10%\", \"15%\", \"20%\"],\n",
     "        ),\n",
-    "        customdata=ind_income_tax_heatmap_df[::-1].transpose().to_numpy().flatten(), # Weird shenanigans.\n",
+    "        customdata=customdata,\n",
     "        hovertemplate = (\n",
     "            \"Year of Assessment: %{x}<br>\"\n",
     "            \"Assessed Income Group: %{y}<br>\"\n",
-    "            \"Mean Net Tax Assessed: %{customdata:.2f}<br>\"\n",
-    "            \"Log Mean Net Tax Assessed: %{z:.2f}\"\n",
+    "            \"Percentage of Assessed Income Paid in Taxes: %{z}<br>\"\n",
+    "            \"Assessable Income: %{customdata[0]}<br>\"\n",
+    "            \"Net Tax Assessed: %{customdata[1]}<br>\"\n",
     "            \"<extra></extra>\"\n",
     "        ),\n",
     "    )\n",
@@ -813,6 +843,13 @@
     "\n",
     "fig"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
At the bottom of the taxes notebook, there is a heatmap that showed the net tax assessed over the years for each assessable income group. However, I realised it's not very insightful to just show the net tax assessed — it's better to show the _percentage_ of the assessable income that was paid in taxes. This PR changes the heatmap to show that.