### PR TITLE
Cache charts and images

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -6,6 +6,7 @@ from components.sidebar import sidebar
 from components.topBar import topbar
 from dash import Dash, dcc, html
 import dash_mantine_components as dmc
+import dashboard.utils
 
 FA = "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
 TW = "https://cdn.tailwindcss.com"
@@ -46,6 +47,6 @@ app.layout = dmc.MantineProvider(
     ],
 )
 
-
 def main():
     app.run(debug=True, dev_tools_hot_reload=True)
+    dashboard.utils.warmup_cache()

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -11,42 +11,49 @@ import dashboard.utils
 FA = "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
 TW = "https://cdn.tailwindcss.com"
 
-app = Dash(
-    __name__, 
-    use_pages=True, 
-    pages_folder="pages", 
-    suppress_callback_exceptions=True,
-    external_stylesheets=[FA] + dmc.styles.ALL,
-    external_scripts=[TW]
-)
-
-app.layout = dmc.MantineProvider(
-    children=[
-        # dcc.location to tracks the current url
-        dcc.Location(id="url", refresh=False),
-
-        html.Div(
-            className="min-h-screen flex flex-col",
-            children=[
-                html.Header(
-                    className="flex-none h-16",
-                    children=[
-                        topbar(),
-                        # sidebar
-                        sidebar(),
+def init_app():
+    app = Dash(
+        __name__, 
+        use_pages=True, 
+        pages_folder="pages", 
+        suppress_callback_exceptions=True,
+        external_stylesheets=[FA] + dmc.styles.ALL,
+        external_scripts=[TW]
+    )
+    
+    app.layout = dmc.MantineProvider(
+        children=[
+            # dcc.location to tracks the current url
+            dcc.Location(id="url", refresh=False),
+    
+            html.Div(
+                className="min-h-screen flex flex-col",
+                children=[
+                    html.Header(
+                        className="flex-none h-16",
+                        children=[
+                            topbar(),
+                            # sidebar
+                            sidebar(),
+                        ]
+                    ),
+                    html.Main(
+                        children=[
+                            # page container
+                            html.Div(dash.page_container, className="p-4 bg-palette1"),
+                        ],
+                    ),
                     ]
                 ),
-                html.Main(
-                    children=[
-                        # page container
-                        html.Div(dash.page_container, className="p-4 bg-palette1"),
-                    ],
-                ),
-                ]
-            ),
-    ],
-)
+        ],
+    )
+
+    with app.server.app_context():
+        dashboard.utils.warmup_cache()
+
+    return app
+
+app = init_app()
 
 def main():
     app.run(debug=True, dev_tools_hot_reload=True)
-    dashboard.utils.warmup_cache()

--- a/dashboard/components/hoverCard.py
+++ b/dashboard/components/hoverCard.py
@@ -1,11 +1,18 @@
 import base64
+import cachetools
+from cachetools.keys import hashkey
+
+import dash_mantine_components as dmc
 import plotly.io as pio
 from dash import dcc, html
-import dash_mantine_components as dmc
 from plotly.graph_objects import Figure
 
 
-def fig_to_base64(fig: Figure, img_format="png") -> str:
+# Cache using the chartID as the key.
+@cachetools.cached(
+    cache={}, key=lambda chartID, fig, img_format="png": hashkey(chartID)
+)
+def fig_to_base64(chartID: str, fig: Figure, img_format: str = "png") -> str:
     img_bytes = pio.to_image(fig, format=img_format)
     encoded = base64.b64encode(img_bytes).decode("ascii")
     return f"data:image/{img_format};base64,{encoded}"
@@ -13,7 +20,7 @@ def fig_to_base64(fig: Figure, img_format="png") -> str:
 
 def hoverableCard(chartID: str, chart: Figure, cardName: str, desc: str, href: str) -> dmc.Card:
     # conver to based64 image
-    img_data = fig_to_base64(chart)
+    img_data = fig_to_base64(chartID, chart)
 
     return html.Div(
         className="group w-full",
@@ -23,7 +30,7 @@ def hoverableCard(chartID: str, chart: Figure, cardName: str, desc: str, href: s
                     # card image
                     dmc.CardSection(
                         html.Img(
-                            src=img_data, 
+                            src=img_data,
                             className="w-auto h-40 block mx-auto "
                         ),
                     ),

--- a/dashboard/pages/global.py
+++ b/dashboard/pages/global.py
@@ -1,5 +1,4 @@
 import dash
-from dash import dcc, html
 from dash.development.base_component import Component
 from plotly.graph_objects import Figure
 import dash_mantine_components as dmc
@@ -12,18 +11,8 @@ import dashboard.utils
 dash.register_page(__name__)
 
 
-def load_charts() -> dict[str, Figure]:
-    return {
-        "cpi_bubble_map": dashboard.utils.load_chart_json("cpi_bubble_map.json"),
-        "gdp_bubble_map": dashboard.utils.load_chart_json("gdp_bubble_map.json"),
-        "cpi_vs_gdp_bubble_chart": dashboard.utils.load_chart_json(
-            "cpi_vs_gdp_bubble_chart.json"
-        ),
-    }
-
-
 def layout() -> Component:
-    charts: dict[str, Figure] = load_charts()
+    charts: dict[str, Figure] = dashboard.utils.load_global_charts()
     return dmc.Stack(
         [
             # header

--- a/dashboard/pages/healthcare.py
+++ b/dashboard/pages/healthcare.py
@@ -12,25 +12,8 @@ import dashboard.utils
 dash.register_page(__name__)
 
 
-def load_charts() -> dict[str, Figure]:
-    return {
-        "life_expectancy_vs_healthcare_cpi": dashboard.utils.load_chart_json(
-            "life_expectancy_vs_healthcare_cpi.json"
-        ),
-        "healthcare_cpi_vs_gross_monthly_income": dashboard.utils.load_chart_json(
-            "healthcare_cpi_vs_gross_monthly_income.json"
-        ),
-        "percentage_change_in_healthcare_cpi_and_income": dashboard.utils.load_chart_json(
-            "percentage_change_in_healthcare_cpi_and_income.json"
-        ),
-        "healthcare_cpi_breakdown": dashboard.utils.load_chart_json(
-            "healthcare_cpi_breakdown.json"
-        ),
-    }
-
-
 def layout() -> Component:
-    charts: dict[str, Figure] = load_charts()
+    charts: dict[str, Figure] = dashboard.utils.load_healthcare_charts()
     return dmc.Stack(
         [
             # header

--- a/dashboard/pages/home.py
+++ b/dashboard/pages/home.py
@@ -10,23 +10,8 @@ from text.home_text import *
 dash.register_page(__name__, path="/")
 
 
-def load_charts() -> dict[str, Figure]:
-    return {
-        "percentage_change_in_healthcare_cpi_and_income": dashboard.utils.load_chart_json(
-            "percentage_change_in_healthcare_cpi_and_income.json"
-        ),
-        "cpi_vs_gst_line_bar": dashboard.utils.load_chart_json(
-            "cpi_vs_gst_line_bar.json"
-        ),
-        "necessities_cpi_vs_income": dashboard.utils.load_chart_json(
-            "necessities_cpi_vs_income.json"
-        ),
-        "cpi_bubble_map": dashboard.utils.load_chart_json("cpi_bubble_map.json"),
-    }
-
-
 def layout():
-    charts: dict[str, Figure] = load_charts()
+    charts: dict[str, Figure] = dashboard.utils.load_home_charts()
 
     return dmc.Stack(
         children=[

--- a/dashboard/pages/necessities.py
+++ b/dashboard/pages/necessities.py
@@ -1,5 +1,5 @@
 import dash
-from dash import dcc, html
+from dash import html
 from dash.development.base_component import Component
 from plotly.graph_objects import Figure
 import dash_mantine_components as dmc
@@ -12,22 +12,8 @@ from components.textComponents import create_card, create_section_title
 dash.register_page(__name__)
 
 
-def load_charts() -> dict[str, Figure]:
-    return {
-        "necessities_cpi_breakdown": dashboard.utils.load_chart_json(
-            "necessities_cpi_breakdown.json"
-        ),
-        "necessities_cpi_vs_income": dashboard.utils.load_chart_json(
-            "necessities_cpi_vs_income.json"
-        ),
-        "monthly_expenditure_donut": dashboard.utils.load_chart_json(
-            "monthly_expenditure_donut.json"
-        ),
-    }
-
-
 def layout() -> Component:
-    charts: dict[str, Figure] = load_charts()
+    charts: dict[str, Figure] = dashboard.utils.load_necessities_charts()
 
     return dmc.Stack(
         [

--- a/dashboard/pages/taxes.py
+++ b/dashboard/pages/taxes.py
@@ -12,33 +12,8 @@ import dashboard.utils
 dash.register_page(__name__)
 
 
-def load_charts() -> dict[str, Figure]:
-    return {
-        "iras_tax_collection_bar": dashboard.utils.load_chart_json(
-            "iras_tax_collection_bar.json"
-        ),
-        "cpi_vs_gst_line_bar": dashboard.utils.load_chart_json(
-            "cpi_vs_gst_line_bar.json"
-        ),
-        "income_tax_rates_step_line": dashboard.utils.load_chart_json(
-            "income_tax_rates_step_line.json"
-        ),
-        "income_tax_heatmap": dashboard.utils.load_chart_json(
-            "income_tax_heatmap.json"
-        ),
-        "property_tax_rates_step_line": dashboard.utils.load_chart_json(
-            "property_tax_rates_step_line.json"
-        ),
-        "property_tax_collection_annual_value_bubble": (
-            dashboard.utils.load_chart_json(
-                "property_tax_collection_annual_value_bubble.json"
-            )
-        ),
-    }
-
-
 def layout() -> Component:
-    charts: dict[str, Figure] = load_charts()
+    charts: dict[str, Figure] = dashboard.utils.load_taxes_charts()
     return dmc.Stack(
         [
             # header

--- a/dashboard/utils.py
+++ b/dashboard/utils.py
@@ -1,3 +1,4 @@
+import functools
 import os.path
 
 import plotly.io
@@ -7,6 +8,75 @@ from plotly.graph_objects import Figure
 CHARTS_DIR: str = "data/charts"
 
 
+@functools.cache
 def load_chart_json(filename: str) -> Figure:
     with flask_app.open_resource(os.path.join(CHARTS_DIR, filename)) as file:
         return plotly.io.from_json(file.read())
+
+
+def load_global_charts() -> dict[str, Figure]:
+    return {
+        "cpi_bubble_map": load_chart_json("cpi_bubble_map.json"),
+        "gdp_bubble_map": load_chart_json("gdp_bubble_map.json"),
+        "cpi_vs_gdp_bubble_chart": load_chart_json("cpi_vs_gdp_bubble_chart.json"),
+    }
+
+
+def load_necessities_charts() -> dict[str, Figure]:
+    return {
+        "necessities_cpi_breakdown": load_chart_json("necessities_cpi_breakdown.json"),
+        "necessities_cpi_vs_income": load_chart_json("necessities_cpi_vs_income.json"),
+        "monthly_expenditure_donut": load_chart_json("monthly_expenditure_donut.json"),
+    }
+
+
+def load_healthcare_charts() -> dict[str, Figure]:
+    return {
+        "life_expectancy_vs_healthcare_cpi": load_chart_json(
+            "life_expectancy_vs_healthcare_cpi.json"
+        ),
+        "healthcare_cpi_vs_gross_monthly_income": load_chart_json(
+            "healthcare_cpi_vs_gross_monthly_income.json"
+        ),
+        "percentage_change_in_healthcare_cpi_and_income": load_chart_json(
+            "percentage_change_in_healthcare_cpi_and_income.json"
+        ),
+        "healthcare_cpi_breakdown": load_chart_json("healthcare_cpi_breakdown.json"),
+    }
+
+
+def load_taxes_charts() -> dict[str, Figure]:
+    return {
+        "iras_tax_collection_bar": load_chart_json("iras_tax_collection_bar.json"),
+        "cpi_vs_gst_line_bar": load_chart_json("cpi_vs_gst_line_bar.json"),
+        "income_tax_rates_step_line": load_chart_json(
+            "income_tax_rates_step_line.json"
+        ),
+        "income_tax_heatmap": load_chart_json("income_tax_heatmap.json"),
+        "property_tax_rates_step_line": load_chart_json(
+            "property_tax_rates_step_line.json"
+        ),
+        "property_tax_collection_annual_value_bubble": (
+            load_chart_json("property_tax_collection_annual_value_bubble.json")
+        ),
+    }
+
+
+def load_home_charts() -> dict[str, Figure]:
+    return {
+        "percentage_change_in_healthcare_cpi_and_income": load_chart_json(
+            "percentage_change_in_healthcare_cpi_and_income.json"
+        ),
+        "cpi_vs_gst_line_bar": load_chart_json("cpi_vs_gst_line_bar.json"),
+        "necessities_cpi_vs_income": load_chart_json("necessities_cpi_vs_income.json"),
+        "cpi_bubble_map": load_chart_json("cpi_bubble_map.json"),
+    }
+
+
+def warmup_cache() -> None:
+    load_global_charts()
+    load_necessities_charts()
+    load_healthcare_charts()
+    load_taxes_charts()
+    # No need to call `load_home_charts()` because all charts should already
+    # have been cached by the above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "flask>=3.0.3",
     "dash-mantine-components>=0.15.3",
     "kaleido>=0.2.1",
+    "cachetools>=5.5.2",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -364,7 +364,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -703,6 +703,7 @@ name = "ict305-project-dashboard"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "cachetools" },
     { name = "dash" },
     { name = "dash-mantine-components" },
     { name = "flask" },
@@ -714,6 +715,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cachetools", specifier = ">=5.5.2" },
     { name = "dash", specifier = ">=2.18.2" },
     { name = "dash-mantine-components", specifier = ">=0.15.3" },
     { name = "flask", specifier = ">=3.0.3" },
@@ -836,7 +838,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "appnope", marker = "platform_system == 'Darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -2312,7 +2314,7 @@ name = "tzlocal"
 version = "5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "tzdata", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/cc/11360404b20a6340b9b4ed39a3338c4af47bc63f87f6cea94dbcbde07029/tzlocal-5.3.tar.gz", hash = "sha256:2fafbfc07e9d8b49ade18f898d6bcd37ae88ce3ad6486842a2e4f03af68323d2", size = 30480 }
 wheels = [


### PR DESCRIPTION
## Description
Caches charts and images. The charts and images are loaded on application startup to warm up the cache. After that, navigating to the different pages should be smooth and no longer trigger IO.

## Related PR or Issue
N/A

## Changes
- Move chart loading functions to `dashboard.utils`.
- Decorate the chart loading functions with `functools.cache`.
- Add a `warmup_cache()` function to `dashboard.utils` that calls the chart loading functions to warm up the cache for chart loading functions.
- Add dependency on `cachetools`.
- Cache the `fig_to_base64()` function. This requires the external `cachetools` package because the built-in `functools.cache` does not allow specifying a cache key. We need to specify a cache key because `Figure` is not hashable. The `chartID` passed to `hoverableCard` is used as the cache ID.