### PR TITLE
Adjustments for mobile

### DIFF
--- a/dashboard/components/app_shell.py
+++ b/dashboard/components/app_shell.py
@@ -3,7 +3,6 @@ import dash_mantine_components as dmc
 from dash import (ClientsideFunction, Input, Output, State,
                   clientside_callback, dcc, html)
 
-
 # title: href
 LINKS: dict[str, str] = {
     "Home": "/",
@@ -51,7 +50,7 @@ def DashboardAppShell() -> dmc.AppShell:
                         dmc.Box(
                             dash.page_container,
                             w=1000,
-                            p="lg",
+                            p="xl",
                         ),
                         align="center",
                         justify="center",
@@ -63,8 +62,8 @@ def DashboardAppShell() -> dmc.AppShell:
             html.Div(
                 id="sidebar-overlay",
                 className="hidden fixed top-0 left-0 w-screen h-screen bg-gray-500 opacity-50 z-40",
-                n_clicks=0
-            )
+                n_clicks=0,
+            ),
         ],
     )
 
@@ -77,7 +76,7 @@ def DashboardHeader() -> dmc.AppShellHeader:
         children=dmc.Group(
             h="100%",
             px="md",
-            className="z-50",
+            wrap="nowrap",
             children=[
                 dmc.Burger(
                     id="mobile-burger",
@@ -94,6 +93,7 @@ def DashboardHeader() -> dmc.AppShellHeader:
                 dmc.Title(
                     "An Analysis of the Cost of Living in Singapore",
                     order=3,
+                    lineClamp=1,
                 ),
             ],
         ),
@@ -157,28 +157,27 @@ def DashboardFooter() -> dmc.Stack:
         gap="lg",
     )
 
+
 clientside_callback(
-    ClientsideFunction(namespace="clientside",
-                       function_name="updateSidebarState"),
+    ClientsideFunction(namespace="clientside", function_name="updateSidebarState"),
     [
-        Output("appshell", "navbar"), 
+        Output("appshell", "navbar"),
         Output("sidebar-overlay", "style"),
         Output("mobile-burger", "opened"),
-        Output("desktop-burger", "opened")
+        Output("desktop-burger", "opened"),
     ],
     [
         Input("mobile-burger", "opened"),
         Input("desktop-burger", "opened"),
         Input("url", "pathname"),
-        Input("sidebar-overlay", "n_clicks")
+        Input("sidebar-overlay", "n_clicks"),
     ],
     State("appshell", "navbar"),
 )
 
 # Update the sidebar link colours based on the current URL.
 clientside_callback(
-    ClientsideFunction(namespace="clientside",
-                       function_name="setActiveNavLink"),
+    ClientsideFunction(namespace="clientside", function_name="setActiveNavLink"),
     *(Output(_id_from_title(title), "active") for title in LINKS.keys()),
     Input("url", "pathname"),
     *(State(_id_from_title(title), "href") for title in LINKS.keys()),

--- a/dashboard/components/graphWrapper.py
+++ b/dashboard/components/graphWrapper.py
@@ -13,6 +13,13 @@ def graphWrapper(id: str, figure: Figure, scale: float = 1.0) -> dmc.Box:
             wrapped_name_list = textwrap.wrap(original_name.strip(), width=20)
             trace.name = "<br>".join(wrapped_name_list)
 
+        # Wrap heatmap colorbar title.
+        if "colorbar" in trace:
+            original_colorbar_title = trace.colorbar.title.text
+            trace.colorbar.title.text = "<br>".join(
+                textwrap.wrap(original_colorbar_title.strip(), width=20)
+            )
+
     figure.update_layout(template="mantine_light")
 
     return dmc.Box(

--- a/dashboard/components/hoverCard.py
+++ b/dashboard/components/hoverCard.py
@@ -44,6 +44,28 @@ def hoverableCard(
                             p=0,
                             h=300,
                             justify="center",
+                            visibleFrom="sm",
+                            children=html.Img(
+                                className="h-auto w-full object-contain",
+                                src=image_src,
+                            ),
+                        ),
+                        dmc.Stack(
+                            p=0,
+                            h=425,
+                            justify="center",
+                            hiddenFrom="sm",
+                            visibleFrom="xs",
+                            children=html.Img(
+                                className="h-auto w-full object-contain",
+                                src=image_src,
+                            ),
+                        ),
+                        dmc.Stack(
+                            p=0,
+                            h=350,
+                            justify="center",
+                            hiddenFrom="xs",
                             children=html.Img(
                                 className="h-auto w-full object-contain",
                                 src=image_src,

--- a/dashboard/pages/home.py
+++ b/dashboard/pages/home.py
@@ -1,8 +1,6 @@
 import dash
 import dash_mantine_components as dmc
-from plotly.graph_objects import Figure
 
-import dashboard.utils
 from dashboard.components.hoverCard import hoverableCard
 from dashboard.components.textComponents import (create_card,
                                                  create_page_title,
@@ -13,7 +11,88 @@ dash.register_page(__name__, path="/")
 
 
 def layout():
-    charts: dict[str, Figure] = dashboard.utils.load_home_charts()
+    # left panel text
+    intro_para_1 = dmc.Stack(
+        children=[
+            dmc.Text(INTRO_1),
+            dmc.Text(INTRO_2),
+        ],
+    )
+
+    # right panel text
+    intro_para_2 = dmc.Stack(
+        children=[
+            dmc.Text(INTRO_BULLET_HEADING),
+            dmc.List(
+                children=[
+                    dmc.ListItem(INTRO_BULLET_1),
+                    dmc.ListItem(INTRO_BULLET_2),
+                    dmc.ListItem(INTRO_BULLET_3),
+                    dmc.ListItem(INTRO_BULLET_4),
+                ],
+            ),
+        ],
+    )
+
+    intro_para_3 = dmc.Text(INTRO_3)
+
+    term_cards = [
+        create_card(
+            "Good Service Tax (GST)",
+            GST_DEF,
+            stackGap=0,
+            dividerKwargs={"size": "sm"},
+        ),
+        create_card(
+            "Gross Domestic Product (GDP) per Capita",
+            GDP_DEF,
+            stackGap=0,
+            dividerKwargs={"size": "sm"},
+        ),
+        create_card(
+            "Consumer Price Index (CPI)",
+            CPI_DEF,
+            stackGap=0,
+            dividerKwargs={"size": "sm"},
+        ),
+        create_card(
+            "Purchasing Power Parity (PPP)",
+            PPP_DEF,
+            stackGap=0,
+            dividerKwargs={"size": "sm"},
+        ),
+    ]
+
+    preview_cards = [
+        hoverableCard(
+            chartID="iras_tax_collection_bar",
+            image_src=dash.get_asset_url("images/tax_preview.png"),
+            cardName="Taxes",
+            desc="Is Singapore's tax system effective? How does it affect different income levels and property values?",
+            href="/taxes",
+        ),
+        hoverableCard(
+            chartID="necessities_cpi_vs_income",
+            image_src=dash.get_asset_url("images/necessities_preview.png"),
+            cardName="Necessities",
+            desc="Are the costs of essential goods and services, such as housing, food, healthcare and transportation, becoming less affordable?",
+            href="/necessities",
+        ),
+        hoverableCard(
+            chartID="percentage_change_in_healthcare_cpi_and_income",
+            image_src=dash.get_asset_url("images/healthcare_preview.png"),
+            cardName="Healthcare",
+            desc="Are healthcare costs rising and impacting affordability and access?",
+            href="/healthcare",
+        ),
+        hoverableCard(
+            chartID="cpi_bubble_map",
+            image_src=dash.get_asset_url("images/global_preview.png"),
+            cardName="Global",
+            desc="How does Singapore's economic situation compare to other countries?",
+            href="/global",
+        ),
+    ]
 
     return dmc.Stack(
         children=[
@@ -25,67 +104,38 @@ def layout():
                 gap="xl",
                 preventGrowOverflow=True,
                 align="flex-start",
+                visibleFrom="sm",
                 children=[
-                    # left panel text
-                    dmc.Stack(
-                        children=[
-                            dmc.Text(INTRO_1),
-                            dmc.Text(INTRO_2),
-                        ],
-                    ),
-                    # right panel text
-                    dmc.Stack(
-                        children=[
-                            dmc.Text(INTRO_BULLET_HEADING),
-                            dmc.List(
-                                children=[
-                                    dmc.ListItem(INTRO_BULLET_1),
-                                    dmc.ListItem(INTRO_BULLET_2),
-                                    dmc.ListItem(INTRO_BULLET_3),
-                                    dmc.ListItem(INTRO_BULLET_4),
-                                ],
-                            ),
-                        ],
-                    ),
+                    intro_para_1,
+                    intro_para_2,
                 ],
             ),
-            dmc.Text(INTRO_3),
+            dmc.Stack(
+                hiddenFrom="sm",
+                children=[
+                    intro_para_1,
+                    intro_para_2,
+                ],
+            ),
+            intro_para_3,
             dmc.Divider(),
             create_section_title("Terminology"),
             dmc.Text(TERMINOLOGY_INTRO),
             dmc.Box(
-                [
+                children=[
                     dmc.SimpleGrid(
                         cols=2,
                         spacing="md",
-                        children=[
-                            create_card(
-                                "Good Service Tax (GST)",
-                                GST_DEF,
-                                stackGap=0,
-                                dividerKwargs={"size": "sm"},
-                            ),
-                            create_card(
-                                "Gross Domestic Product (GDP) per Capita",
-                                GDP_DEF,
-                                stackGap=0,
-                                dividerKwargs={"size": "sm"},
-                            ),
-                            create_card(
-                                "Consumer Price Index (CPI)",
-                                CPI_DEF,
-                                stackGap=0,
-                                dividerKwargs={"size": "sm"},
-                            ),
-                            create_card(
-                                "Purchasing Power Parity (PPP)",
-                                PPP_DEF,
-                                stackGap=0,
-                                dividerKwargs={"size": "sm"},
-                            ),
-                        ],
+                        visibleFrom="sm",
+                        children=term_cards,
                         className="my-6",
-                    )
+                    ),
+                    dmc.Stack(
+                        gap="md",
+                        hiddenFrom="sm",
+                        children=term_cards,
+                        className="my-6",
+                    ),
                 ],
             ),
             dmc.Divider(),
@@ -95,38 +145,16 @@ def layout():
                     dmc.SimpleGrid(
                         cols=2,
                         spacing="md",
-                        children=[
-                            hoverableCard(
-                                chartID="iras_tax_collection_bar",
-                                image_src=dash.get_asset_url("images/tax_preview.png"),
-                                cardName="Taxes",
-                                desc="Is Singapore's tax system effective? How does it affect different income levels and property values?",
-                                href="/taxes",
-                            ),
-                            hoverableCard(
-                                chartID="necessities_cpi_vs_income",
-                                image_src=dash.get_asset_url("images/necessities_preview.png"),
-                                cardName="Necessities",
-                                desc="Are the costs of essential goods and services, such as housing, food, healthcare and transportation, becoming less affordable?",
-                                href="/necessities",
-                            ),
-                            hoverableCard(
-                                chartID="percentage_change_in_healthcare_cpi_and_income",
-                                image_src=dash.get_asset_url("images/healthcare_preview.png"),
-                                cardName="Healthcare",
-                                desc="Are healthcare costs rising and impacting affordability and access?",
-                                href="/healthcare",
-                            ),
-                            hoverableCard(
-                                chartID="cpi_bubble_map",
-                                image_src=dash.get_asset_url("images/global_preview.png"),
-                                cardName="Global",
-                                desc="How does Singapore's economic situation compare to other countries?",
-                                href="/global",
-                            ),
-                        ],
+                        visibleFrom="sm",
+                        children=preview_cards,
                         className="my-6",
-                    )
+                    ),
+                    dmc.Stack(
+                        gap="xl",
+                        hiddenFrom="sm",
+                        children=preview_cards,
+                        className="my-6",
+                    ),
                 ],
             ),
             dmc.Divider(),


### PR DESCRIPTION
Some adjustments for mobile:
- Increase minimum padding for all pages.
- Fix title in the header moving to the next line on mobile.
- On the home page, don't use a 2 by 2 grid on mobile. Instead, just stack them from top to bottom.
- Apply text wrapping to heatmap colorbar title.